### PR TITLE
Issue/dipose on unloaded

### DIFF
--- a/Samples/SampleControl/SampleControl.csproj
+++ b/Samples/SampleControl/SampleControl.csproj
@@ -36,21 +36,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="SharpDX, Version=3.0.2.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpDX.3.0.2\lib\net45\SharpDX.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="SharpDX, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <HintPath>..\..\WpfSharpDxControl\packages\SharpDX.4.2.0\lib\net45\SharpDX.dll</HintPath>
     </Reference>
-    <Reference Include="SharpDX.Direct2D1, Version=3.0.2.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpDX.Direct2D1.3.0.2\lib\net45\SharpDX.Direct2D1.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="SharpDX.Direct2D1, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <HintPath>..\..\WpfSharpDxControl\packages\SharpDX.Direct2D1.4.2.0\lib\net45\SharpDX.Direct2D1.dll</HintPath>
     </Reference>
-    <Reference Include="SharpDX.DXGI, Version=3.0.2.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpDX.DXGI.3.0.2\lib\net45\SharpDX.DXGI.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="SharpDX.DXGI, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <HintPath>..\..\WpfSharpDxControl\packages\SharpDX.DXGI.4.2.0\lib\net45\SharpDX.DXGI.dll</HintPath>
     </Reference>
-    <Reference Include="SharpDX.Mathematics, Version=3.0.2.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpDX.Mathematics.3.0.2\lib\net45\SharpDX.Mathematics.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="SharpDX.Mathematics, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <HintPath>..\..\WpfSharpDxControl\packages\SharpDX.Mathematics.4.2.0\lib\net45\SharpDX.Mathematics.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/Samples/SampleControl/packages.config
+++ b/Samples/SampleControl/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="SharpDX" version="3.0.2" targetFramework="net452" />
-  <package id="SharpDX.Direct2D1" version="3.0.2" targetFramework="net452" />
-  <package id="SharpDX.DXGI" version="3.0.2" targetFramework="net452" />
-  <package id="SharpDX.Mathematics" version="3.0.2" targetFramework="net452" />
+  <package id="SharpDX" version="4.2.0" targetFramework="net45" />
+  <package id="SharpDX.Direct2D1" version="4.2.0" targetFramework="net45" />
+  <package id="SharpDX.DXGI" version="4.2.0" targetFramework="net45" />
+  <package id="SharpDX.Mathematics" version="4.2.0" targetFramework="net45" />
 </packages>

--- a/WpfSharpDxControl/Win32HwndControl.cs
+++ b/WpfSharpDxControl/Win32HwndControl.cs
@@ -32,19 +32,13 @@ namespace WpfSharpDxControl
         private void OnLoaded(object sender, RoutedEventArgs routedEventArgs)
         {
             Initialize();
-            HwndInitialized = true;
-
-            Loaded -= OnLoaded;
+            HwndInitialized = true;         
         }
 
         private void OnUnloaded(object sender, RoutedEventArgs routedEventArgs)
         {
             Uninitialize();
             HwndInitialized = false;
-
-            Unloaded -= OnUnloaded;
-
-            Dispose();
         }
 
         protected abstract void Initialize();

--- a/WpfSharpDxControl/WpfSharpDxControl.csproj
+++ b/WpfSharpDxControl/WpfSharpDxControl.csproj
@@ -33,25 +33,20 @@
   <ItemGroup>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="SharpDX, Version=3.0.2.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>packages\SharpDX.3.0.2\lib\net45\SharpDX.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="SharpDX, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <HintPath>packages\SharpDX.4.2.0\lib\net45\SharpDX.dll</HintPath>
     </Reference>
-    <Reference Include="SharpDX.Direct2D1, Version=3.0.2.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>packages\SharpDX.Direct2D1.3.0.2\lib\net45\SharpDX.Direct2D1.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="SharpDX.Direct2D1, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <HintPath>packages\SharpDX.Direct2D1.4.2.0\lib\net45\SharpDX.Direct2D1.dll</HintPath>
     </Reference>
-    <Reference Include="SharpDX.Direct3D11, Version=3.0.2.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>packages\SharpDX.Direct3D11.3.0.2\lib\net45\SharpDX.Direct3D11.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="SharpDX.Direct3D11, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <HintPath>packages\SharpDX.Direct3D11.4.2.0\lib\net45\SharpDX.Direct3D11.dll</HintPath>
     </Reference>
-    <Reference Include="SharpDX.DXGI, Version=3.0.2.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>packages\SharpDX.DXGI.3.0.2\lib\net45\SharpDX.DXGI.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="SharpDX.DXGI, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <HintPath>packages\SharpDX.DXGI.4.2.0\lib\net45\SharpDX.DXGI.dll</HintPath>
     </Reference>
-    <Reference Include="SharpDX.Mathematics, Version=3.0.2.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>packages\SharpDX.Mathematics.3.0.2\lib\net45\SharpDX.Mathematics.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="SharpDX.Mathematics, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <HintPath>packages\SharpDX.Mathematics.4.2.0\lib\net45\SharpDX.Mathematics.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/WpfSharpDxControl/packages.config
+++ b/WpfSharpDxControl/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="SharpDX" version="3.0.2" targetFramework="net452" />
-  <package id="SharpDX.Direct2D1" version="3.0.2" targetFramework="net452" />
-  <package id="SharpDX.Direct3D11" version="3.0.2" targetFramework="net452" />
-  <package id="SharpDX.DXGI" version="3.0.2" targetFramework="net452" />
-  <package id="SharpDX.Mathematics" version="3.0.2" targetFramework="net452" />
+  <package id="SharpDX" version="4.2.0" targetFramework="net45" />
+  <package id="SharpDX.Direct2D1" version="4.2.0" targetFramework="net45" />
+  <package id="SharpDX.Direct3D11" version="4.2.0" targetFramework="net45" />
+  <package id="SharpDX.DXGI" version="4.2.0" targetFramework="net45" />
+  <package id="SharpDX.Mathematics" version="4.2.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
In reference to issue #4 . Invoking `Dispose` on `FrameworkElement.Unloaded` is incorrect since `Loaded` and `Unloaded` will be frequently raised by parent controls during the lifetime of a WpfSharpDxControl.
